### PR TITLE
Modify git hook execution to include arguments

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
                   paths = hooks;
                 }
               }/bin/*; do
-              $hook
+              $hook "$@"
               RESULT=$?
               if [ $RESULT != 0 ]; then
                   echo "$hook returned non-zero: $RESULT, abort operation"


### PR DESCRIPTION
I tried to use this library with `prepare-commit-msg`, but that command expects arguments. The fix was simple: make sure the git hooks set up by this library pass arguments through.